### PR TITLE
feat: switch to net and ef 6.0

### DIFF
--- a/src/Caching.SqlServer.Demo.Api/Caching.SqlServer.Demo.Api.csproj
+++ b/src/Caching.SqlServer.Demo.Api/Caching.SqlServer.Demo.Api.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.5" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.5" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="5.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.13" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.13" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="7.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Caching.SqlServer.Demo.Api/Caching.SqlServer.Demo.Api.csproj
+++ b/src/Caching.SqlServer.Demo.Api/Caching.SqlServer.Demo.Api.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.13" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.13" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="6.0.13" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Caching.SqlServer.Demo.Api/appsettings.json
+++ b/src/Caching.SqlServer.Demo.Api/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "CacheDbConnection": "data source=.;initial catalog=CachingSample;user id=sa;password=sa;MultipleActiveResultSets=True;TrustServerCertificate=True;"
+    "CacheDbConnection": "data source=.;initial catalog=CachingSample;user id=sa;password=sa;MultipleActiveResultSets=True;"
   }
 }

--- a/src/Caching.SqlServer.Demo.Api/appsettings.json
+++ b/src/Caching.SqlServer.Demo.Api/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "CacheDbConnection": "data source=.;initial catalog=CachingSample;user id=sa;password=sa;MultipleActiveResultSets=True;"
+    "CacheDbConnection": "data source=.;initial catalog=CachingSample;user id=sa;password=sa;MultipleActiveResultSets=True;TrustServerCertificate=True;"
   }
 }

--- a/src/Caching.SqlServer.Infastructure/Caching.SqlServer.Infastructure.csproj
+++ b/src/Caching.SqlServer.Infastructure/Caching.SqlServer.Infastructure.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildThisFileName).xml</DocumentationFile>
     <ProjectGuid>{082EABC5-A9E9-4582-9034-C9FBF3326FE8}</ProjectGuid>
     <PackageId>Caching.SqlServer.Infastructure</PackageId>
-    <Version>5.0.05</Version>
+    <Version>6.0.0</Version>
     <Authors>Dejan Stojanovic</Authors>
     <PackageIcon>icon.png</PackageIcon>
     <Description>Setting up Microsoft SQL Server caching for ASP.NET Core</Description>
@@ -21,14 +21,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="5.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="7.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <None Include="icon.png" Pack="true" PackagePath="\" />
 	</ItemGroup>
 

--- a/src/Caching.SqlServer.Infastructure/Caching.SqlServer.Infastructure.csproj
+++ b/src/Caching.SqlServer.Infastructure/Caching.SqlServer.Infastructure.csproj
@@ -21,14 +21,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.13">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="7.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.13" />
+		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="6.0.13" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <None Include="icon.png" Pack="true" PackagePath="\" />
 	</ItemGroup>
 


### PR DESCRIPTION
Hello, after migrating to .net and ef 6 my application this lib became incompatible, so I updated the references of this project. I did some tests in my scenario and it worked perfectly.

I would like to leave the contribution.

**Caching.SqlServer.Demo.Api**
Microsoft.AspNetCore.Authentication.JwtBearer to 6.0.13
Microsoft.AspNetCore.Authentication.OpenIdConnect to 6.0.13
Microsoft.Extensions.Caching.SqlServer to 6.0.13
Swashbuckle.AspNetCore to 6.5.0

**Caching.SqlServer.Infastructure**
Microsoft.EntityFrameworkCore.Design to 6.0.13
Microsoft.EntityFrameworkCore.SqlServer to 6.0.13
Microsoft.Extensions.Caching.SqlServer to 6.0.13
Microsoft.Extensions.Configuration to 6.0.1
Microsoft.Extensions.Configuration.Json to 6.0.0