### PR TITLE
Update to .net7.0 and framework version 7.0.11

### DIFF
--- a/src/Caching.SqlServer.Demo.Api/Caching.SqlServer.Demo.Api.csproj
+++ b/src/Caching.SqlServer.Demo.Api/Caching.SqlServer.Demo.Api.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.13" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.13" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="6.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.11" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.11" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="7.0.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Caching.SqlServer.Infastructure/Caching.SqlServer.Infastructure.csproj
+++ b/src/Caching.SqlServer.Infastructure/Caching.SqlServer.Infastructure.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildThisFileName).xml</DocumentationFile>
     <ProjectGuid>{082EABC5-A9E9-4582-9034-C9FBF3326FE8}</ProjectGuid>
     <PackageId>Caching.SqlServer.Infastructure</PackageId>
-    <Version>6.0.0</Version>
+    <Version>7.0.0</Version>
     <Authors>Dejan Stojanovic</Authors>
     <PackageIcon>icon.png</PackageIcon>
     <Description>Setting up Microsoft SQL Server caching for ASP.NET Core</Description>
@@ -22,16 +22,16 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.13">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.13" />
-		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="6.0.13" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="7.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <None Include="icon.png" Pack="true" PackagePath="\" />
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
Update to .net7.0 and framework version 7.0.11. This update is required to fix a MissingMethodException that occurs when initialising a new blank database. When the migration is run it throws a missing method exception and fails to start correctly. After updating to .net7.0 the exception no longer occurs.

I am not quite sure why it is required to update this project to .net7.0 to be compatible with .net7.0 projects but in my experience the migration fails if you don't. An instance that already has a deployed database and does not require any migration still works with the net6 version. Its just when trying to migrate a brand new database.